### PR TITLE
build: If img.itb is built, attempt to copy it to the tftp directory

### DIFF
--- a/board/common/post-image.sh
+++ b/board/common/post-image.sh
@@ -95,6 +95,9 @@ fi
 if [ -n "$TFTPDIR" -a -e $img.img ]; then
     echo "xfering '$img' -> '$TFTPDIR/$fn'"
     scp -B $img.img $TFTPDIR
+    if [ "$NETBOX_IMAGE_FIT" ]; then
+        scp -B $img.itb $TFTPDIR
+    fi
 fi
 
 exit $err


### PR DESCRIPTION
build: If $img.itb is built, attempt to copy it to the tftp directory for convenience reasons.
@troglobit @wkz 