### PR TITLE
PoE: Added PoE-support

### DIFF
--- a/dts/coronet/4012-viper-212-t3g-poe-lv/device-tree.dts
+++ b/dts/coronet/4012-viper-212-t3g-poe-lv/device-tree.dts
@@ -1,0 +1,14 @@
+#include <coronet/a12-cpu.dtsi>
+#include <coronet/viper-poe-80W.dtsi>
+
+/ {
+	model = "wmo,Viper-212A-T3G-P8-LV";
+};
+
+&agate {
+	ports {
+		/* ethX2/3 use two-pair M12 connector */
+		port@0 { max-speed = <100>; };
+		port@4 { max-speed = <100>; };
+	};
+};

--- a/dts/include/coronet/a12-cpu.dtsi
+++ b/dts/include/coronet/a12-cpu.dtsi
@@ -43,11 +43,51 @@
 				};
 			};
 
-			mv6_port(0, "ethX2" , &aphy0, "gmii");
+			agate_port0: port@0 {
+				phy-handle = <&aphy0>;
+				reg = <0>;
+				label = "ethX2";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "gmii";
+			};
+
+			agate_port1: port@1 {
+				phy-handle = <&aphy1>;
+				reg = <1>;
+				label = "ethX12";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "gmii";
+			};
+
+			agate_port2: port@2 {
+				phy-handle = <&aphy2>;
+				reg = <2>;
+				label = "ethX8";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "gmii";
+			};
+
+			agate_port3: port@3 {
+				phy-handle = <&aphy3>;
+				reg = <3>;
+				label = "ethX4";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "gmii";
+			};
+
+			agate_port4: port@4 {
+				phy-handle = <&aphy4>;
+				reg = <4>;
+				label = "ethX3";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "gmii";
+			};
+
+			/* mv6_port(0, "ethX2" , &aphy0, "gmii");
 			mv6_port(1, "ethX12", &aphy1, "gmii");
 			mv6_port(2, "ethX8" , &aphy2, "gmii");
 			mv6_port(3, "ethX4" , &aphy3, "gmii");
-			mv6_port(4, "ethX3" , &aphy4, "gmii");
+			mv6_port(4, "ethX3" , &aphy4, "gmii"); */
 		};
 
 		mdio {
@@ -91,13 +131,69 @@
 				};
 			};
 
-			mv6_port(0, "ethX1" , &ophy0, "mii");
+			opal_port0: port@0 {
+				phy-handle = <&ophy0>;
+				reg = <0>;
+				label = "ethX1";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port1: port@1 {
+				phy-handle = <&ophy1>;
+				reg = <1>;
+				label = "ethX5";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port2: port@2 {
+				phy-handle = <&ophy2>;
+				reg = <2>;
+				label = "ethX6";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port3: port@3 {
+				phy-handle = <&ophy3>;
+				reg = <3>;
+				label = "ethX7";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port4: port@4 {
+				phy-handle = <&ophy4>;
+				reg = <4>;
+				label = "ethX9";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port5: port@5 {
+				phy-handle = <&ophy5>;
+				reg = <5>;
+				label = "ethX10";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			opal_port6: port@6 {
+				phy-handle = <&ophy6>;
+				reg = <6>;
+				label = "ethX11";
+				local-mac-address = [00 00 00 00 00 00];
+				phy-mode = "mii";
+			};
+
+			/*	mv6_port(0, "ethX1" , &ophy0, "mii");
 			mv6_port(1, "ethX5" , &ophy1, "mii");
 			mv6_port(2, "ethX6" , &ophy2, "mii");
 			mv6_port(3, "ethX7" , &ophy3, "mii");
 			mv6_port(4, "ethX9" , &ophy4, "mii");
 			mv6_port(5, "ethX10", &ophy5, "mii");
-			mv6_port(6, "ethX11", &ophy6, "mii");
+			mv6_port(6, "ethX11", &ophy6, "mii"); */
 		};
 
 		mdio {

--- a/dts/include/coronet/viper-poe-80W.dtsi
+++ b/dts/include/coronet/viper-poe-80W.dtsi
@@ -1,0 +1,7 @@
+#include "viper-poe.dtsi"
+
+&soc {
+	weos-poe {
+		power-capacity = <80000>;
+	};
+};

--- a/dts/include/coronet/viper-poe.dtsi
+++ b/dts/include/coronet/viper-poe.dtsi
@@ -1,0 +1,83 @@
+&soc {
+	i2c3: i2c@119000 {
+		pd69104@20 {
+			compatible = "pd69104";
+			reg = <0x20>;
+		};
+		pd69104@24 {
+			compatible = "pd69104";
+			reg = <0x24>;
+		};
+	};
+
+	weos-poe {
+		compatible = "westermo,poe-ctrl";
+		interrupt-parent = <&gpio2>;
+		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
+
+		port0 {
+			/* ethX6 */
+			ethport = < &opal_port2 >;
+			/* ethport = < &{/mdio0/switch@4} >; */
+			id = <0>;
+			prio = <4>;
+			device-address = <0x20>;
+		};
+
+		port1 {
+			/* ethX5 */
+			ethport = <&opal_port1>;
+			id = <1>;
+			prio = <3>;
+			device-address = <0x20>;
+		};
+
+		port2 {
+			/* ethX1 */
+			ethport = <&opal_port0>;
+			id = <2>;
+			prio = <0>;
+			device-address = <0x20>;
+		};
+
+		port3 {
+			/* ethX2 */
+			ethport = <&agate_port0>;
+			id = <3>;
+			prio = <1>;
+			device-address = <0x20>;
+		};
+
+		port4 {
+			/* ethX10 */
+			ethport = <&opal_port5>;
+			id = <4>;
+			prio = <7>;
+			device-address = <0x24>;
+		};
+
+		port5 {
+			/* ethX9 */
+			ethport = <&opal_port4>;
+			id = <5>;
+			prio = <6>;
+			device-address = <0x24>;
+		};
+
+		port6 {
+			/* ethX3 */
+			ethport = <&agate_port4>; 
+			id = <6>;
+			prio = <2>;
+			device-address = <0x24>;
+		};
+
+		port7 {
+			/* ethX7 */
+			ethport = <&opal_port3>;
+			id = <7>;
+			prio = <5>;
+			device-address = <0x24>;
+		};
+	};
+};


### PR DESCRIPTION
PoE: Added the 4012 product with PoE-support.

Comment; I needed to create explicit node names for ports, e.g.
agate_port2 to be able to reference the node from PoE port
definitions. I have tried with full path references i.e.
mdio0/switch@4/port@5 or similar, but have failed. It is a future
improvement to be able to use the mv6_port macros again, unless
someone can help.