### PR TITLE
Enable RSTP by default on br0

### DIFF
--- a/board/common/post-build.sh
+++ b/board/common/post-build.sh
@@ -31,6 +31,15 @@ printf "Type: 'help' for help with commands, 'exit' to log out.\n\n" >> $TARGET_
 rm    $TARGET_DIR/etc/dropbear
 mkdir $TARGET_DIR/etc/dropbear
 
+# Make sure we have /sbin/bridge-stp and /etc/default/mstpd set up
+if [ "$BR2_PACKAGE_MSTPD" = "y" ]; then
+    [ -e "$TARGET_DIR/sbin/bridge-stp" ]   || ln -s ../usr/sbin/bridge-stp "$TARGET_DIR/sbin/"
+    [ -e "$TARGET_DIR/etc/default/mstpd" ] || ln -s ../bridge-stp.conf "$TARGET_DIR/etc/default/mstpd"
+
+    grep -qE "^MSTP_BRIDGES=.*" "$TARGET_DIR/etc/bridge-stp.conf" || \
+	echo "MSTP_BRIDGES=br0" >> "$TARGET_DIR/etc/bridge-stp.conf"
+fi
+
 if [ "$NETBOX_PLAT" != "app" ]; then
     kernel=$(basename $TARGET_DIR/boot/*Image)
 

--- a/board/common/rootfs/etc/network/interfaces
+++ b/board/common/rootfs/etc/network/interfaces
@@ -6,7 +6,7 @@ iface lo inet loopback
 # as untagged members in the same VLAN (VID 1).
 auto br0
 iface br0 inet manual
-	pre-up    ip link add dev br0 type bridge stp_state 0 \
+	pre-up    ip link add dev br0 type bridge stp_state 1 \
 			vlan_filtering 1 mcast_vlan_snooping 1
 	pre-up    ip link set group port master br0
 	pre-up    ip link set group port up

--- a/board/common/rootfs/lib/system/if
+++ b/board/common/rootfs/lib/system/if
@@ -40,6 +40,14 @@ awk -F: '
         print("link set dev", $1, " group port");
     }' </proc/net/dev | ip -batch -
 
+# Default to auto-edge in mstpd
+if [ -e /etc/bridge-stp.conf ]; then
+    tmp="$(ip -br link show group port | cut -d' ' -f1 |sed 's/$/=yes /g' |tr -d '\n')"
+    grep -qE '^IF_MSTPCTL_PORTAUTOEDGE.*' /etc/bridge-stp.conf || \
+	echo  "IF_MSTPCTL_PORTAUTOEDGE='$tmp'" >> /etc/bridge-stp.conf
+fi
+
+# Check for and fix duplicate MAC addresses
 if [ "$(ip -br link show group port | uniq -f 2 -d)" ]; then
     logger $opt -p user.warning -t "$ident" \
        "Port MAC addresses not unique, assigning from randomized base MAC."

--- a/package/skeleton-init-finit/skeleton-init-finit.mk
+++ b/package/skeleton-init-finit/skeleton-init-finit.mk
@@ -45,6 +45,14 @@ endef
 SKELETON_INIT_FINIT_TARGET_FINALIZE_HOOKS += SKELETON_INIT_FINIT_SET_DROPBEAR
 endif
 
+# mstpd provides RSTP on the default bridge
+ifeq ($(BR2_PACKAGE_MSTPD),y)
+define SKELETON_INIT_FINIT_SET_MSTPD
+	ln -sf ../available/mstpd.conf $(FINIT_D)/enabled/mstpd.conf
+endef
+SKELETON_INIT_FINIT_TARGET_FINALIZE_HOOKS += SKELETON_INIT_FINIT_SET_MSTPD
+endif
+
 # Enable Busybox syslogd unless sysklogd is enabled
 ifeq ($(BR2_PACKAGE_SYSKLOGD),y)
 define SKELETON_INIT_FINIT_SET_SYSLOGD

--- a/package/skeleton-init-finit/skeleton/etc/finit.d/available/mstpd.conf
+++ b/package/skeleton-init-finit/skeleton/etc/finit.d/available/mstpd.conf
@@ -1,0 +1,1 @@
+sysv name:mstpd [23456789] env:-/etc/default/mstpd bridge-stp $MSTPD_ARGS -- MSTP daemon

--- a/patches/mstpd/0.1.0/busybox-pidof.patch
+++ b/patches/mstpd/0.1.0/busybox-pidof.patch
@@ -1,0 +1,26 @@
+--- mstpd-0.1.0/bridge-stp.in.orig	2022-02-04 11:49:59.764280663 +0100
++++ mstpd-0.1.0/bridge-stp.in	2022-02-04 11:51:00.212347703 +0100
+@@ -139,7 +139,7 @@
+         fi
+ 
+         # Start mstpd if necessary.
+-        if ! pidof -c -s mstpd >/dev/null; then
++        if ! pidof -s mstpd >/dev/null; then
+             if [ "$MANAGE_MSTPD" != 'y' ]; then
+                 errmsg 'mstpd is not running'
+                 exit 3
+@@ -212,12 +212,12 @@
+         done
+ 
+         # Kill mstpd, since no bridges are currently using it.
+-        kill $(pidof -c mstpd)
++        kill $(pidof mstpd)
+         ;;
+     restart|restart_config)
+         if [ "$action" = 'restart' ]; then
+             # Kill mstpd.
+-            pids="$(pidof -c mstpd)" ; Err=$?
++            pids="$(pidof mstpd)" ; Err=$?
+             if [ $Err -eq 0 ]; then
+                 echo 'Stopping mstpd ...'
+                 kill $pids


### PR DESCRIPTION
In discussion #23 I presented the plans for enabling RSTP by default on br0 in NetBox.  See that thread for details and motivation.

This patch enables RSTP using mstpd, with fallback to bridge STP.  All bridge ports are by default set as "auto-edge", meaning mstpd will take them to forwarding much quicker than traditional STP (2 x 15 sec).  It also continuously monitors for STP BPDUs, switching the port between edge and no-edge automatically.

**Note:** this patch builds on PR #22 and should possibly be rebased and force-pushed when #22 has been merged.  I've pushed this PR so we can discuss the technical implications.
