### PR TITLE
board/common: adapt mdev-like-a-boss.conf to Buildroot groups

### DIFF
--- a/board/common/rootfs/etc/mdev.conf
+++ b/board/common/rootfs/etc/mdev.conf
@@ -23,10 +23,10 @@ hwrandom    root:root 444
 grsec       root:root 660
 
 # Kernel-based Virtual Machine.
-kvm     root:kvm 660
+#kvm     root:kvm 660
 
 # vhost-net, to be used with kvm.
-vhost-net   root:kvm 660
+#vhost-net   root:kvm 660
 
 kmem        root:root 640
 mem         root:root 640
@@ -40,7 +40,7 @@ pty.*       root:tty 660
 tty         root:tty 666
 tty[0-9]*   root:tty 660
 vcsa*[0-9]* root:tty 660
-ttyS[0-9]*  root:uucp 660
+ttyS[0-9]*  root:dialout 660
 
 # block devices
 ram([0-9]*)        root:disk 660 >rd/%1
@@ -54,7 +54,7 @@ fd[0-9]*           root:floppy 660
 # run 'settle-nis' without '--write-mactab' param.
 #-SUBSYSTEM=net;DEVPATH=.*/net/.*;.*     root:root 600 @/lib/system/settle-nics --write-mactab
 
-net/tun[0-9]*   root:kvm 660
+net/tun[0-9]*   root:netdev 660
 net/tap[0-9]*   root:root 600
 
 # alsa sound devices and audio stuff
@@ -82,7 +82,7 @@ psaux       root:root 660 >misc/
 rtc         root:root 664 >misc/
 
 # input stuff
-SUBSYSTEM=input;.* root:input 660
+SUBSYSTEM=input;.* root:plugdev 660
 
 # v4l stuff
 vbi[0-9]    root:video 660 >v4l/


### PR DESCRIPTION
The Buildroot default groups are derived from Debian/Ubuntu, whereas the
mdev-like-a-boss groups used in their mdev.conf seem to be from Fedora.

This patch aligns mdev.conf with Buildroot default group names and also
disables a few kvm related rules.  The idea is to be able to implement
mulitple users as easily as possible using group membership instead of
having all users be root.

Signed-off-by: Joachim Wiberg <troglobit@gmail.com>