### PR TITLE
Set an explanation for string attribute on NETBOX_PLAT in Config.in

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -1,7 +1,7 @@
 menu "Branding"
 
 config NETBOX_PLAT
-	string
+	string "Single word lower-case identifier for the platform"
 	default "basis"   if BR2_arm926t
 	default "coronet" if BR2_powerpc
 	default "dagger"  if BR2_arm


### PR DESCRIPTION
In order to set other platforms than those defaulted by the arch
the strin attribute needs to hold a value. This is needed now when
we have more than one platform with the same arch type.

Signed-off-by: Lennart Eriksson <lennart.eriksson@westermo.com>